### PR TITLE
VIH-7603 Update pipelines with correct names and ensure always at least 1 day when calling ELinks API for judiciary users.

### DIFF
--- a/SchedulerJobs/SchedulerJobs/Functions/GetJudiciaryUsersFunction.cs
+++ b/SchedulerJobs/SchedulerJobs/Functions/GetJudiciaryUsersFunction.cs
@@ -29,7 +29,7 @@ namespace SchedulerJobs.Functions
         [FunctionName("GetJudiciaryUsersFunction")]
         public async Task RunAsync([TimerTrigger("0 0 2 * * *", RunOnStartup = true)] TimerInfo myTimer, ILogger log)
         {
-            var days = _servicesConfiguration?.ELinksApiGetPeopleUpdatedSinceDays ?? 1;
+            var days = Math.Max(_servicesConfiguration?.ELinksApiGetPeopleUpdatedSinceDays ?? 1, 1);
             var updatedSince = DateTime.UtcNow.AddDays(-days);
             
             log.LogInformation("Started GetJudiciaryUsersFunction at: {Now} - param UpdatedSince: {UpdatedSince}", 

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -140,7 +140,7 @@ stages:
           - name: VhServices:ELinksApiKey
             value: vh-services-elinks-api-key
             secret: true
-          - name: VhServices:ELinksApiGetPeopleUpdatedSinceDay
+          - name: VhServices:ELinksApiGetPeopleUpdatedSinceDays
             value: vh-services-elinks-api-get-people-updated-since-days
             secret: true
         acceptanceTestSettings:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,7 @@ parameters:
   - name: VhServices:ELinksApiKey
     value: vh-services-elinks-api-key
     secret: true
-  - name: VhServices:ELinksApiGetPeopleUpdatedSinceDay
+  - name: VhServices:ELinksApiGetPeopleUpdatedSinceDays
     value: vh-services-elinks-api-get-people-updated-since-days
     secret: true
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-7603


### Change description ###
Updating yml files to have correct values.
Calls to Elinks will now always be at least 1 day previous.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
