### PR TITLE
VIH-7938 separated the elinks api url for prod and staging

### DIFF
--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -52,6 +52,11 @@ variables:
       value: 'false'
     ${{ if ne(parameters.environment, 'Prod') }}:
       value: 'true'
+  - name: ELinksApiUrl
+    ${{ if eq(parameters.environment, 'Prod') }}:
+      value: $(elinks_api_url)
+    ${{ if ne(parameters.environment, 'Prod') }}:
+      value: $(elinks_api_url_staging)
 
 trigger: none
 pr: none
@@ -141,7 +146,7 @@ stages:
           - name: VhServices:UserApiUrl
             value: $(user_api_url)
           - name: VhServices:ELinksApiUrl
-            value: $(elinks_api_url)
+            value: $(ELinksApiUrl)
           - name: VhServices:ELinksApiKey
             value: vh-services-elinks-api-key
             secret: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,7 @@ parameters:
   - name: VhServices:UserApiUrl
     value: $(user_api_url)
   - name: VhServices:ELinksApiUrl
-    value: $(elinks_api_url)
+    value: $(elinks_api_url_staging)
   - name: VhServices:ELinksApiKey
     value: vh-services-elinks-api-key
     secret: true


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/VIH-7938

### Change description ###

- VIH-7938 separated the elinks api url for prod and staging
-
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
