### PR TITLE
VIH-9712 remove dev and stg environment from relase pipelines

### DIFF
--- a/azure-pipelines.sds.release.yml
+++ b/azure-pipelines.sds.release.yml
@@ -16,8 +16,7 @@ parameters:
 - name: environment
   type: object
   default:
-  - Dev
-  - Staging
+  - Demo
   - Prod
 
 pool: 
@@ -49,8 +48,6 @@ stages:
     variables:
       - ${{ if contains(variables['Build.SourceBranch'], 'refs/heads/release') }}:
         - template: variables/production.yaml
-      - ${{ else }}:
-        - template: variables/staging.yaml
       - template: variables/shared.yaml
     jobs:
       - job: Docker_Build
@@ -91,8 +88,6 @@ stages:
     variables:
       - ${{ if contains(variables['Build.SourceBranch'], 'refs/heads/release') }}:
         - template: variables/production.yaml
-      - ${{ else }}:
-        - template: variables/staging.yaml
         
       - template: variables/shared.yaml
       - group: vh-github-app-credentials

--- a/azure-pipelines.sds.release.yml
+++ b/azure-pipelines.sds.release.yml
@@ -12,13 +12,6 @@ resources:
       ref: master
       endpoint: hmcts
 
-parameters:
-- name: environment
-  type: object
-  default:
-  - Demo
-  - Prod
-
 pool: 
   vmImage: ubuntu-22.04
 

--- a/variables/demo.yaml
+++ b/variables/demo.yaml
@@ -1,0 +1,3 @@
+variables:
+  - name: env
+    value: "demo"

--- a/variables/demo.yaml
+++ b/variables/demo.yaml
@@ -1,3 +1,0 @@
-variables:
-  - name: env
-    value: "demo"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9712?filter=-1


### Change description ###
Removing the Dev and Stg environments from vh-admin-web and vh-schedular-job



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
