### PR TITLE
VIH-11291 Fix for audio reconciliation failures

### DIFF
--- a/SchedulerJobs/SchedulerJobs.Services.UnitTests/ReconcileHearingAudioServiceTests.cs
+++ b/SchedulerJobs/SchedulerJobs.Services.UnitTests/ReconcileHearingAudioServiceTests.cs
@@ -46,8 +46,11 @@ namespace SchedulerJobs.Services.UnitTests
         {
             var conferenceRoomHearingResponses1 = new List<ConferenceHearingRoomsResponse>();
 
-            conferenceRoomHearingResponses1.Add(new ConferenceHearingRoomsResponse() { HearingId = Guid.NewGuid().ToString(), FileNamePrefix = string.Empty, Label = string.Empty });
-            conferenceRoomHearingResponses1.Add(new ConferenceHearingRoomsResponse() { HearingId = Guid.NewGuid().ToString(), FileNamePrefix = string.Empty, Label = string.Empty });
+            var hearing1Id = Guid.NewGuid();
+            var hearing2Id = Guid.NewGuid();
+            
+            conferenceRoomHearingResponses1.Add(new ConferenceHearingRoomsResponse { HearingId = hearing1Id.ToString(), FileNamePrefix = $"ABA4-Hearing1-{hearing1Id}", Label = string.Empty });
+            conferenceRoomHearingResponses1.Add(new ConferenceHearingRoomsResponse { HearingId = hearing2Id.ToString(), FileNamePrefix = $"BCA1-Hearing2-{hearing2Id}", Label = string.Empty });
 
             _videoApiClient.Setup(x => x.GetConferencesHearingRoomsAsync(It.IsAny<string>())).ReturnsAsync(conferenceRoomHearingResponses1);
             _videoApiClient.SetupSequence(x => x.ReconcileAudioFilesInStorageAsync(It.IsAny<string>(), It.IsAny<int>())).ReturnsAsync(true).ReturnsAsync(true);

--- a/SchedulerJobs/SchedulerJobs.Services/ReconcileHearingAudioService.cs
+++ b/SchedulerJobs/SchedulerJobs.Services/ReconcileHearingAudioService.cs
@@ -28,7 +28,7 @@ namespace SchedulerJobs.Services
 
            _logger.LogInformation("ReconcileAudiorecordingsWithConferencesAsync - Conferences count {ConferenceCount}", + conferences.Count);
 
-           var audioConferenceItems = conferences.Select(x => x.HearingId).GroupBy(x => x).Select( g => new { Name = g.Key, Count = g.Count()});
+           var audioConferenceItems = conferences.Select(x => x.FileNamePrefix).GroupBy(x => x).Select( g => new { Name = g.Key, Count = g.Count()});
 
            foreach (var item in audioConferenceItems)
            {

--- a/charts/vh-scheduler-jobs/values.dev.template.yaml
+++ b/charts/vh-scheduler-jobs/values.dev.template.yaml
@@ -1,8 +1,6 @@
 ---
 image: '${IMAGE_NAME}'
 releaseNameOverride: ${RELEASE_NAME}
-environment:
-  VHSERVICES__VIDEOAPIURL: https://vh-video-api-pr-718.dev.platform.hmcts.net/
 crons:
   - cronJobName: vh-anonymise-hearings-and-conferences-job-pr-${PR_NUMBER}
     schedule: "5 8 * * *"

--- a/charts/vh-scheduler-jobs/values.dev.template.yaml
+++ b/charts/vh-scheduler-jobs/values.dev.template.yaml
@@ -1,6 +1,8 @@
 ---
 image: '${IMAGE_NAME}'
 releaseNameOverride: ${RELEASE_NAME}
+environment:
+  VHSERVICES__VIDEOAPIURL: https://vh-video-api-pr-718.dev.platform.hmcts.net/
 crons:
   - cronJobName: vh-anonymise-hearings-and-conferences-job-pr-${PR_NUMBER}
     schedule: "5 8 * * *"


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/VIH-11291

### Change description
- The filename prefix for audio recordings was changed a while ago from {hearing id} to {service id}-{case number}-{hearing id}. Use this new prefix instead of the hearing id when looking them up in video api for reconciliation